### PR TITLE
enable-backgroundだとWarningが出てしまうのを修正

### DIFF
--- a/pages/article/[slug].tsx
+++ b/pages/article/[slug].tsx
@@ -301,7 +301,7 @@ export default function ArticlePage({
                   Next post
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    enable-background="new 0 0 24 24"
+                    enableBackground="new 0 0 24 24"
                     height="24px"
                     viewBox="0 0 24 24"
                     width="24px"


### PR DESCRIPTION
Newt使用させていただいております。
こちらのテンプレートで一点ワーニングが出てしまっていたので修正PRを送らさせていただきます。

<img width="845" alt="Newtバグ" src="https://user-images.githubusercontent.com/38300385/163678962-2a1a6545-6f1e-4a0e-98c7-b61d5375810f.png">

このように`Invalid DOM property `enable-background`.`とWarningが出てしまうため修正いたしました。