### PR TITLE
searchTextに初期値を設定

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,7 +9,7 @@ export function Header({ app }: { app: AppMeta }): JSX.Element {
   const { q } = router.query;
   const searchRef = useRef<HTMLInputElement>();
 
-  const [searchText, setSearchText] = useState(q);
+  const [searchText, setSearchText] = useState(q || "");
 
   const focus = useCallback(() => {
     if (searchRef.current) {


### PR DESCRIPTION
以下のwarningが出ているので、初期値を設定して対応する。

> A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen.